### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/gamma_limits_sensitivity/__init__.py
+++ b/gamma_limits_sensitivity/__init__.py
@@ -225,8 +225,7 @@ def plot_lambda_s(
 
     plt.clabel(cset, inline=True, fmt='%1.1f', fontsize=10)
 
-    plt.title('signal counts per %1.1f h, E$_0$=%1.1f TeV assuming power law' %
-              (t_obs/3600., E_0))
+    plt.title('signal counts per {0:1.1f} h, E$_0$={1:1.1f} TeV assuming power law'.format(t_obs/3600., E_0))
     plt.xlabel('$f_0$ / [(cm$^2$ s TeV)$^{-1}$]')
     plt.ylabel('$\\Gamma$')
     return lambda_s


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mahnen:gamma_limits_sensitivity?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mahnen:gamma_limits_sensitivity?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)