### PR TITLE
Adopt python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script: # configure a headless display to test plot generation
 - sleep 3 # give xvfb some time to start
 language: python
 python:
-- '3.5'
+- '3.6'
 install:
 - pip install -e .
 - pip install pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     url='https://github.com/mahnen/gamma_limits_sensitivity',
     author='Max Ahnen',
     author_email='m.knoetig@gmail.com',
-    licence='MIT',
+    license='MIT',
     packages=[
         'gamma_limits_sensitivity'
     ],

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ setup(
             'gamma_limits_sensitivity = gamma_limits_sensitivity.__main__:main'
         ]
     },
-    install_requires={
+    install_requires=[
         'numpy',
         'scipy',
         'matplotlib',
         'docopt',
         'corner'
-    },
+    ],
     tests_require=['pytest']
 )


### PR DESCRIPTION
The default python version in anaconda today is 3.6
I propose to adopt the modern python 3.6.

To pip install the package with the latest anaconda and python 3.6, two minor changes were made in the setup.py. See issues #2, #3, #4.

I am not sure yet whether more changes are needed for the rest of the repo to work in python 3.6.
